### PR TITLE
fix to build in ROS2 eloquent

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,11 @@
     <depend>message_runtime</depend>
     <depend>std_msgs</depend>
 
+    <!-- ROS2 dependencies -->
+    <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+    <member_of_group condition="$ROS_VERSION == 2">rosidl_interface_packages</member_of_group>
+    
     <export>
-
+        <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
     </export>
 </package>


### PR DESCRIPTION
Resolves #1 , and allows package to be built in ROS2 Eloquent. Related to facontidavide/PlotJuggler#304, facontidavide/PlotJuggler#306